### PR TITLE
Add title replacement capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ jobs:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"                   # required - allows the action to make calls to GitHub's rest API
         branch-regex: 'FOO-\d+'                                     # required - regex to match text from the head branch name
         lowercase-branch: true                                      # optional - whether to lowercase branch name before matching
-        title-template: '[%branch%]'                                # optional - text template to prefix title
+        title-replace-template: '${{ github.head_ref }}'            # optional - whether to set the title to this value
+        title-prefix-template: '[%branch%]'                         # optional - text template to prefix title, can be used with replace, or independently
         title-prefix-space: true                                    # optional - whether to add a space after title prefix
         uppercase-title: true                                       # optional - whether to uppercase title prefix
         body-template: '[%branch%](https://browse/ticket/%branch%)' # optional - text template to prefix body
@@ -51,7 +52,8 @@ jobs:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         branch-regex: 'foo-\d+'
         lowercase-branch: false
-        title-template: '[%branch%]'
+        #title-replace-template: '${{ github.head_ref }}'            # optional - whether to set the title to this value
+        title-prefix-template: '[%branch%]'
         title-prefix-space: true
         uppercase-title: true
         body-template: '[Link to %branch%](https://url/to/browse/ticket/%branch%)'

--- a/action.yml
+++ b/action.yml
@@ -18,8 +18,11 @@ inputs:
     default: true
   title-template:
     description: 'Title prefix template where branch info gets substituted in'
-    required: true
+    required: false
     default: '[%branch%]'
+  title-replace-template:
+    description: 'Title template that replaces the existing title rather than prefixing it as title-template'
+    required: false
   title-prefix-space:
     description: 'Should add space after title prefix'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -17,11 +17,15 @@ inputs:
     required: false
     default: true
   title-template:
+    description: 'Title prefix template where branch info gets substituted in -- equivalent to title-prefix-template but present for backward compatibility'
+    required: false
+    default: '[%branch%]'
+  title-prefix-template:
     description: 'Title prefix template where branch info gets substituted in'
     required: false
     default: '[%branch%]'
   title-replace-template:
-    description: 'Title template that replaces the existing title rather than prefixing it as title-template'
+    description: 'Title template that replaces the existing title -- this can be used in addition to prefixing'
     required: false
   title-prefix-space:
     description: 'Should add space after title prefix'

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ async function run() {
       branchRegex: core.getInput('branch-regex', {required: true}),
       lowercaseBranch: (core.getInput('lowercase-branch').toLowerCase() === 'true'),
       titleTemplate: core.getInput('title-template'),
+      titlePrefixTemplate: core.getInput('title-prefix-template'),
       titleReplaceTemplate: core.getInput('title-replace-template'),
       titlePrefixSpace: (core.getInput('title-prefix-space').toLowerCase() === 'true'),
       uppercaseTitle: (core.getInput('uppercase-title').toLowerCase() === 'true'),
@@ -50,7 +51,8 @@ async function run() {
       core.warning('PR title set not requested or set already - no updates made');
     }
 
-    const titlePrefix = inputs.titleTemplate ? inputs.titleTemplate.replace(tokenRegex, match(inputs.uppercaseTitle)) : null;
+    const configuredTitleTemplate = inputs.titlePrefixTemplate || inputs.titleTemplate;
+    const titlePrefix = configuredTitleTemplate ? configuredTitleTemplate.replace(tokenRegex, match(inputs.uppercaseTitle)) : null;
     core.debug(`titlePrefix: ${titlePrefix}`);
 
     const prefixTitle = titlePrefix && !(request.title || title).toLowerCase().startsWith(titlePrefix.toLowerCase());


### PR DESCRIPTION
Fixes issue #4 . It isn't one or the other anymore -- the title can both be set and prefixed, or only one or the other.